### PR TITLE
Create missing parent directories when installing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ man7_targets = \
 all: install
 
 install:
-	install -m 644 $(man1_targets) $(man1)
-	install -m 644 $(man7_targets) $(man7)
+	install -D -m 644 -t $(man1) $(man1_targets)
+	install -D -m 644 -t $(man7) $(man7_targets)
 
 uninstall:
 	cd $(man1); rm -f $(man1_targets)


### PR DESCRIPTION
With this change, if parent directories of `$(man1)` and `$(man7)` do not exist, they will be created when installing the man pages. It's equivalent to running
```sh
mkdir -p $(man1) $(man7)
```
in the `install` target.